### PR TITLE
Fixed table key creation and deletion

### DIFF
--- a/SQL/create_tables.sql
+++ b/SQL/create_tables.sql
@@ -30,7 +30,8 @@ CREATE TABLE tbl_addresses
 	country VARCHAR(50) NOT NULL,
 	is_business BIT NOT NULL,
 
-	FOREIGN KEY (user_id) REFERENCES dbo.tbl_users(id)
+    CONSTRAINT FK_address_user FOREIGN KEY(user_id)
+    REFERENCES dbo.tbl_users(id)
 );
 
 CREATE TABLE tbl_user_tokens
@@ -40,6 +41,7 @@ CREATE TABLE tbl_user_tokens
 	token UNIQUEIDENTIFIER NOT NULL,
 	expiry_date DATETIME NOT NULL
 
-	FOREIGN KEY (user_id) REFERENCES dbo.tbl_users(id)
+	CONSTRAINT FK_user_tokens_user FOREIGN KEY(user_id)
+    REFERENCES dbo.tbl_users(id)
 );
 

--- a/SQL/delete_tables.sql
+++ b/SQL/delete_tables.sql
@@ -1,5 +1,11 @@
 USE FalconAmazonDB;
 
+IF EXISTS(SELECT * FROM sys.foreign_keys WHERE parent_object_id = OBJECT_ID('dbo.tbl_addresses'))
+    ALTER TABLE dbo.tbl_addresses DROP CONSTRAINT FK_address_user;
+
+IF EXISTS(SELECT * FROM sys.foreign_keys WHERE parent_object_id = OBJECT_ID('dbo.tbl_user_tokens'))
+    ALTER TABLE dbo.tbl_user_tokens DROP CONSTRAINT FK_user_tokens_user;
+
 IF OBJECT_ID('dbo.tbl_addresses', 'U') IS NOT NULL  
     DROP TABLE dbo.tbl_addresses;
 


### PR DESCRIPTION
Changed the way the foreign keys are created so that they are given names. This allows them to be dropped just before the tables are ( in the delete script ) as not doing so stops the tables from being dropped.